### PR TITLE
Multi threaded throughput tester

### DIFF
--- a/mqtt_spammer/mqtt_spammer.py
+++ b/mqtt_spammer/mqtt_spammer.py
@@ -7,6 +7,21 @@ port = 1883
 topic = "mqtt_spammer"
 
 
+"""
+Flux query to get the number of records inside of the database.
+
+from(bucket: "telegraf_data")
+  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+  |> filter(fn: (r) => r["_measurement"] == "votes")
+ |> group()
+  |> sort(columns: ["_time"])
+
+  |> keep(columns: ["_value"])
+  |> count()
+
+"""
+
+
 class spammer(threading.Thread):
     client_id = ''
 


### PR DESCRIPTION
A script to check if the server can handle the load. 

Testscript is run on my local machine with the combination of mosquitto, telegraf & influxdb running in docker. A 1000 clients connect to the broker, each sending a 1000 messages. The result is 999 942 messages inside of the database (58 are missing). All 1 000 000 messages were send over a time period of around 2 minutes.

Currently I would think this is 'good enough'.

![image](https://user-images.githubusercontent.com/66962646/142777749-353638ea-b28e-4645-a6bf-7b398505aab2.png)
